### PR TITLE
Add links to correct AUR package name

### DIFF
--- a/readme.mkd
+++ b/readme.mkd
@@ -84,7 +84,7 @@ To use the latest release/pre-built jars:
 
 This will sync the `$HOME/code` directory on your two machines.
 
-(Note: for Arch Linux users, AUR has the `mirror-tool` and `mirror-tool-git` packages.)
+(Note: for Arch Linux users, AUR has the [`mirror-sync`](https://aur.archlinux.org/packages/mirror-sync) and [`mirror-sync-git`](https://aur.archlinux.org/packages/mirror-sync-git) packages.)
 
 Config
 ======


### PR DESCRIPTION
Hi there, I tried to find the `mirror-tool` package on the AUR and was unable to do so. `mirror-sync` appears to be the correct package name, as mentioned in #51.